### PR TITLE
Incompatibility with PHP 5.2

### DIFF
--- a/decoda/Decoda.php
+++ b/decoda/Decoda.php
@@ -402,7 +402,7 @@ class Decoda {
 			$this->_extractChunks();
 			$this->_parsed = $this->_parse($this->_nodes);
 		} else {
-			$this->_parsed = nl2br($this->_string, $this->config('xhtml'));
+			$this->_parsed = self::nl2br($this->_string, $this->config('xhtml'));
 		}
 
 		$this->_parsed = $this->_trigger('afterParse', $this->_parsed);
@@ -1020,7 +1020,7 @@ class Decoda {
 		foreach ($nodes as $node) {
 			if (is_string($node)) {
 				if (empty($wrapper)) {
-					$parsed .= nl2br($node, $xhtml);
+					$parsed .= self::nl2br($node, $xhtml);
 				} else {
 					$parsed .= $node;
 				}
@@ -1050,6 +1050,23 @@ class Decoda {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Inserts HTML line breaks before all newlines in a string.
+	 * If the server is running PHP 5.2, the second parameter will be ignored
+	 * 
+	 * @access public
+	 * @param string $string
+	 * @param bool $xhtml
+	 * @return string
+	 */
+	public static function nl2br($string, $is_xhtml = true) {
+		if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+			return nl2br($string);
+		} else {
+			return nl2br($string, $is_xhtml);
+		}
 	}
 
 }

--- a/decoda/DecodaFilter.php
+++ b/decoda/DecodaFilter.php
@@ -107,7 +107,7 @@ abstract class DecodaFilter extends DecodaAbstract {
 				$content = str_replace(array("\n", "\r"), "", $content);
 			break;
 			case self::NL_CONVERT:
-				$content = nl2br($content, $xhtml);
+				$content = Decoda::nl2br($content, $xhtml);
 			break;
 		}
 


### PR DESCRIPTION
func_get_args can be used in parameter lists only in PHP 5.3.0
