### PR TITLE
support for attribute aliases

### DIFF
--- a/decoda/Decoda.php
+++ b/decoda/Decoda.php
@@ -710,6 +710,10 @@ class Decoda {
 							$key = 'default';
 						}
 
+                        if (isset($source['alias'][$key])) {
+                            $key = $source['alias'][$key];
+                        }
+
 						if (isset($source['attributes'][$key])) {
 							$pattern = $source['attributes'][$key];
 


### PR DESCRIPTION
Supports for example a long and short name for a tag attribute. But the attribute only needs to be defined once with it's corresponding validation regex.

[tag long_name_for_attribute="value"][/tag] will act the same as [tag short="value"][/tag] when the alias is defined for the tag in its filter class.
