### PR TITLE
Supporting relative/absolute Images paths

### DIFF
--- a/src/Decoda/Filter/ImageFilter.php
+++ b/src/Decoda/Filter/ImageFilter.php
@@ -18,7 +18,7 @@ class ImageFilter extends AbstractFilter {
 	/**
 	 * Regex pattern.
 	 */
-	const IMAGE_PATTERN = '/^(?:https?:)?\/\/(.*?)\.(?:jpg|jpeg|png|gif|bmp)$/is';
+	const IMAGE_PATTERN = '/^(?:https?:\/)?(?:.){0,2}\/(.*?)\.(?:jpg|jpeg|png|gif|bmp)$/is';
 	const DIMENSION = '/^[0-9%]{1,4}+$/';
 
 	/**


### PR DESCRIPTION
I'm not a regexp expert but i tried adding support for those kinds of paths :

/img/file.png
./img/file.png
../img/file.png

By moving one "/" inside the optional "http" part of the regexp, and adding "(?:.){0,2}".
It works fine and doesn't seem to break anything as far as i know.

If anyone is interested, i needed this in order to work with CKEditor and KCFinder image upload/insertion.
