### PR TITLE
Fix Component::setParser method signature to allow null value

### DIFF
--- a/src/Decoda/Component.php
+++ b/src/Decoda/Component.php
@@ -72,6 +72,6 @@ interface Component {
 	 * @param \Decoda\Decoda $parser
 	 * @return \Decoda\Component
 	 */
-	public function setParser(Decoda $parser);
+	public function setParser(Decoda $parser = null);
 
 }

--- a/src/Decoda/Component/AbstractComponent.php
+++ b/src/Decoda/Component/AbstractComponent.php
@@ -125,7 +125,7 @@ abstract class AbstractComponent implements Component {
 	 * @param \Decoda\Decoda $parser
 	 * @return \Decoda\Component
 	 */
-	public function setParser(Decoda $parser) {
+	public function setParser(Decoda $parser = null) {
 		$this->_parser = $parser;
 
 		return $this;

--- a/tests/Decoda/Hook/CensorHookTest.php
+++ b/tests/Decoda/Hook/CensorHookTest.php
@@ -20,7 +20,8 @@ class CensorHookTest extends TestCase {
 		parent::setUp();
 
 		$this->object = new CensorHook();
-		$this->object->setParser(new Decoda());
+		// This Hook don't depends from Decoda
+		// $this->object->setParser(new Decoda());
 		$this->object->startup();
 	}
 


### PR DESCRIPTION
Allow case when the parser is not set yet.
