### PR TITLE
Fix triggered as self closing tags instead of opening tags

### DIFF
--- a/src/Decoda/Decoda.php
+++ b/src/Decoda/Decoda.php
@@ -885,16 +885,6 @@ class Decoda {
 			$tag = trim(mb_substr($string, 2, mb_strlen($string) - 3));
 			$type = self::TAG_CLOSE;
 
-		// Self closing tag
-		} else if (mb_substr($string, -2) === '/' . $ce) {
-			$tag = trim(mb_substr($string, 1, mb_strlen($string) - 3));
-			$type = self::TAG_SELF_CLOSE;
-
-			// Check if spaces or attributes exist
-			if ($pos = mb_strpos($tag, ' ')) {
-				$tag = mb_substr($tag, 0, $pos);
-			}
-
 		// Opening tag
 		} else if (preg_match('/' . preg_quote($oe, '/') . '([-a-z0-9]+)(.*?)' . preg_quote($ce, '/') . '/i', $string, $matches)) {
 			$tag = trim($matches[1]);
@@ -908,6 +898,17 @@ class Decoda {
 
 		if (!isset($this->_tags[$tag])) {
 			return false;
+		}
+
+		if (self::TAG_OPEN === $type) {
+			// Check if is a self closing tag
+			if (
+				isset($this->_tags[$tag]['autoClose']) &&
+				$this->_tags[$tag]['autoClose'] === true &&
+				mb_substr($string, -2) === '/' . $ce
+			) {
+				$type = self::TAG_SELF_CLOSE;
+			}
 		}
 
 		// Find attributes

--- a/src/Decoda/Hook/EmptyHook.php
+++ b/src/Decoda/Hook/EmptyHook.php
@@ -12,23 +12,4 @@ namespace Decoda\Hook;
  */
 class EmptyHook extends AbstractHook {
 
-	/**
-	 * Fix weird problems.
-	 *
-	 * @param string $string
-	 * @return string
-	 */
-	public function beforeParse($string) {
-
-		// Fix URLs that end in trailing slash by wrapping them in double quotes
-		// This causes URLs to be triggered as self closing tags instead of opening tags
-		if ($this->getParser()->hasFilter('Url')) {
-			$string = preg_replace_callback('/\[url=(.*?)\]/i', function($matches) {
-				return sprintf('[url="%s"]', trim($matches[1], '"'));
-			}, $string);
-		}
-
-		return $string;
-	}
-
 }

--- a/tests/Decoda/Filter/UrlFilterTest.php
+++ b/tests/Decoda/Filter/UrlFilterTest.php
@@ -44,6 +44,13 @@ class UrlFilterTest extends TestCase {
 		// Test URLs with a trailing slash
 		$this->assertEquals('<a href="http://domain.com/">http://domain.com/</a>', $this->object->reset('[url]http://domain.com/[/url]')->parse());
 		$this->assertEquals('<a href="http://domain.com/">Test</a>', $this->object->reset('[url="http://domain.com/"]Test[/url]')->parse());
+
+	}
+
+	public function testUrlWhenStrictIsFalse() {
+		$this->object->setStrict(false);
+
+		// Test URLs with a trailing slash
 		$this->assertEquals('<a href="http://domain.com/">Test</a>', $this->object->reset('[url=http://domain.com/]Test[/url]')->parse());
 	}
 


### PR DESCRIPTION
<table>
  <tr>
    <th>Q</th><th>A</th>
  </tr>
  <tr>
    <td>Bug fix?</td><td>yes</td>
  </tr>
  <tr>
    <td>New feature?</td><td>no</td>
  </tr>
  <tr>
    <td>BC breaks?</td><td>no</td>
  </tr>
  <tr>
    <td>Tests pass?</td><td>yes</td>
  </tr>
  <tr>
    <td>Fixed tickets</td><td>#40</td>
  </tr>
  <tr>
    <td>License?</td><td>MIT</td>
  </tr>
</table>
