### PR TITLE
Render <br> fix.

### DIFF
--- a/src/Decoda/Filter/AbstractFilter.php
+++ b/src/Decoda/Filter/AbstractFilter.php
@@ -157,7 +157,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
 			// Process line breaks
 			switch ($setup['lineBreaks']) {
 				case Decoda::NL_CONVERT:
-					$content = str_replace("\r", "", $parser->convertLineBreaks($content));
+					$content = str_replace(array("\r", "\n"), "", $parser->convertLineBreaks($content));
 				break;
 				case Decoda::NL_REMOVE:
 					$content = str_replace(array("\r", "\n"), "", $content);


### PR DESCRIPTION
Miles,

we find small issue with line breaks converting. When we parsing BBCode

``` html
[center][color=#DB1702][b][size=4]Information[/size][/b][/color]
[color=#14496b]
[b]
string 1
string 2
string 3
[/b][/color]
[/center]
```

we get next

``` html
string 1<br><br><br>
string 2<br><br><br>
string 3<br><br><br>
```

our fix decreases count of line breaks & we get next render

``` html
string 1<br>string 2<br>string 3<br>
```

Thx
