### PR TITLE
Test for whitespace insertion if trailing in a tag

### DIFF
--- a/tests/Decoda/DecodaTest.php
+++ b/tests/Decoda/DecodaTest.php
@@ -193,6 +193,14 @@ class DecodaTest extends TestCase {
     }
 
     /**
+     * Test that a whitespace is inserted if it trails a tag
+     */
+    public function testInsertsWhitespaceInsideTag() {
+        $this->object->addFilter(new DefaultFilter());
+        $this->assertEquals(substr_count($this->object->reset('[b]Bold [/b]String')->parse(), ' '), 1);
+    }
+
+    /**
      * Test that setShorthand() applies short hand variations for URL and email.
      */
     public function testShorthand() {


### PR DESCRIPTION
Some RTE's allow users to insert formatting like `[b]bold string [/b]goes here`. The last space is stripped out from inside the tag, resulting in no space being shown better the letters, demonstrated by the test. Unfortunately I don't have the time to get into the code and patch this myself :/
