### PR TITLE
Replace @type with @var

### DIFF
--- a/src/Decoda/Component/AbstractComponent.php
+++ b/src/Decoda/Component/AbstractComponent.php
@@ -19,21 +19,21 @@ abstract class AbstractComponent implements Component {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array();
 
     /**
      * List of Loaders.
      *
-     * @type \Decoda\Loader[]
+     * @var \Decoda\Loader[]
      */
     protected $_loaders = array();
 
     /**
      * Decoda object.
      *
-     * @type \Decoda\Decoda
+     * @var \Decoda\Decoda
      */
     protected $_parser;
 

--- a/src/Decoda/Decoda.php
+++ b/src/Decoda/Decoda.php
@@ -61,21 +61,21 @@ class Decoda {
     /**
      * Blacklist of tags not to parse.
      *
-     * @type array
+     * @var array
      */
     protected $_blacklist = array();
 
     /**
      * Extracted chunks of text and tags.
      *
-     * @type array
+     * @var array
      */
     protected $_chunks = array();
 
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'open' => '[',
@@ -94,91 +94,91 @@ class Decoda {
     /**
      * Logged errors for incorrectly nested nodes and types.
      *
-     * @type array
+     * @var array
      */
     protected $_errors = array();
 
     /**
      * List of all instantiated filter objects.
      *
-     * @type array
+     * @var array
      */
     protected $_filters = array();
 
     /**
      * Mapping of tags to its filter object.
      *
-     * @type array
+     * @var array
      */
     protected $_filterMap = array();
 
     /**
      * List of all instantiated hook objects.
      *
-     * @type array
+     * @var array
      */
     protected $_hooks = array();
 
     /**
      * Message strings for localization purposes.
      *
-     * @type array
+     * @var array
      */
     protected $_messages = array();
 
     /**
      * Children nodes.
      *
-     * @type array
+     * @var array
      */
     protected $_nodes = array();
 
     /**
      * The parsed string.
      *
-     * @type string
+     * @var string
      */
     protected $_parsed = '';
 
     /**
      * Configuration folder paths.
      *
-     * @type array
+     * @var array
      */
     protected $_paths = array();
 
     /**
      * The raw string before parsing.
      *
-     * @type string
+     * @var string
      */
     protected $_string = '';
 
     /**
      * The stripped string.
      *
-     * @type string
+     * @var string
      */
     protected $_stripped = '';
 
     /**
      * List of tags from filters.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array();
 
     /**
      * Template engine used for parsing.
      *
-     * @type \Decoda\Engine
+     * @var \Decoda\Engine
      */
     protected $_engine = null;
 
     /**
      * Whitelist of tags to parse.
      *
-     * @type array
+     * @var array
      */
     protected $_whitelist = array();
 

--- a/src/Decoda/Engine/AbstractEngine.php
+++ b/src/Decoda/Engine/AbstractEngine.php
@@ -19,14 +19,14 @@ abstract class AbstractEngine extends AbstractComponent implements Engine {
     /**
      * Lookup paths.
      *
-     * @type array
+     * @var array
      */
     protected $_paths = array();
 
     /**
      * Current filter.
      *
-     * @type \Decoda\Filter
+     * @var \Decoda\Filter
      */
     protected $_filter;
 

--- a/src/Decoda/Filter/AbstractFilter.php
+++ b/src/Decoda/Filter/AbstractFilter.php
@@ -21,7 +21,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
     /**
      * Default tag configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_defaults = array(
         /**
@@ -87,7 +87,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array();
 

--- a/src/Decoda/Filter/BlockFilter.php
+++ b/src/Decoda/Filter/BlockFilter.php
@@ -17,7 +17,7 @@ class BlockFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'spoilerToggle' => "$('#spoiler-content-{id}').toggle();"
@@ -26,7 +26,7 @@ class BlockFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'align' => array(

--- a/src/Decoda/Filter/CodeFilter.php
+++ b/src/Decoda/Filter/CodeFilter.php
@@ -18,7 +18,7 @@ class CodeFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'classPrefix' => 'lang-',
@@ -28,7 +28,7 @@ class CodeFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'code' => array(

--- a/src/Decoda/Filter/DefaultFilter.php
+++ b/src/Decoda/Filter/DefaultFilter.php
@@ -18,7 +18,7 @@ class DefaultFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'timeFormat' => 'D, M jS Y, H:i'
@@ -27,7 +27,7 @@ class DefaultFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'b' => array(

--- a/src/Decoda/Filter/EmailFilter.php
+++ b/src/Decoda/Filter/EmailFilter.php
@@ -17,7 +17,7 @@ class EmailFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'encrypt' => true
@@ -26,7 +26,7 @@ class EmailFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'email' => array(

--- a/src/Decoda/Filter/EmptyFilter.php
+++ b/src/Decoda/Filter/EmptyFilter.php
@@ -15,7 +15,7 @@ class EmptyFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'root' => array()

--- a/src/Decoda/Filter/ImageFilter.php
+++ b/src/Decoda/Filter/ImageFilter.php
@@ -24,7 +24,7 @@ class ImageFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'img' => array(

--- a/src/Decoda/Filter/ListFilter.php
+++ b/src/Decoda/Filter/ListFilter.php
@@ -19,7 +19,7 @@ class ListFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'olist' => array(

--- a/src/Decoda/Filter/QuoteFilter.php
+++ b/src/Decoda/Filter/QuoteFilter.php
@@ -17,7 +17,7 @@ class QuoteFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'dateFormat' => 'M jS Y, H:i:s'
@@ -26,7 +26,7 @@ class QuoteFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'quote' => array(

--- a/src/Decoda/Filter/TableFilter.php
+++ b/src/Decoda/Filter/TableFilter.php
@@ -17,7 +17,7 @@ class TableFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'table' => array(

--- a/src/Decoda/Filter/TextFilter.php
+++ b/src/Decoda/Filter/TextFilter.php
@@ -17,7 +17,7 @@ class TextFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'font' => array(

--- a/src/Decoda/Filter/UrlFilter.php
+++ b/src/Decoda/Filter/UrlFilter.php
@@ -17,7 +17,7 @@ class UrlFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'protocols' => array('http', 'https', 'ftp', 'irc', 'telnet'),
@@ -27,7 +27,7 @@ class UrlFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'url' => array(

--- a/src/Decoda/Filter/VideoFilter.php
+++ b/src/Decoda/Filter/VideoFilter.php
@@ -23,7 +23,7 @@ class VideoFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'video' => array(
@@ -131,7 +131,7 @@ class VideoFilter extends AbstractFilter {
     /**
      * Video formats.
      *
-     * @type array
+     * @var array
      */
     protected $_formats = array(
         'youtube' => array(

--- a/src/Decoda/Hook/CensorHook.php
+++ b/src/Decoda/Hook/CensorHook.php
@@ -18,14 +18,14 @@ class CensorHook extends AbstractHook {
     /**
      * List of words to censor.
      *
-     * @type array
+     * @var array
      */
     protected $_blacklist = array();
 
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'suffix' => array('ing', 'in', 'er', 'r', 'ed', 'd')

--- a/src/Decoda/Hook/EmoticonHook.php
+++ b/src/Decoda/Hook/EmoticonHook.php
@@ -18,7 +18,7 @@ class EmoticonHook extends AbstractHook {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = array(
         'path' => '/images/',
@@ -28,14 +28,14 @@ class EmoticonHook extends AbstractHook {
     /**
      * Mapping of emoticons to smilies.
      *
-     * @type array
+     * @var array
      */
     protected $_emoticons = array();
 
     /**
      * Map of smilies to emoticons.
      *
-     * @type array
+     * @var array
      */
     protected $_smilies = array();
 

--- a/src/Decoda/Loader/DataLoader.php
+++ b/src/Decoda/Loader/DataLoader.php
@@ -15,7 +15,7 @@ class DataLoader extends AbstractLoader {
     /**
      * Raw data.
      *
-     * @type mixed
+     * @var mixed
      */
     protected $_data;
 

--- a/src/Decoda/Loader/FileLoader.php
+++ b/src/Decoda/Loader/FileLoader.php
@@ -18,7 +18,7 @@ class FileLoader extends AbstractLoader {
     /**
      * Path to file.
      *
-     * @type string
+     * @var string
      */
     protected $_path;
 

--- a/tests/Decoda/Test/TestCase.php
+++ b/tests/Decoda/Test/TestCase.php
@@ -14,7 +14,7 @@ class TestCase extends \PHPUnit_Framework_TestCase {
     /**
      * Decoda instance.
      *
-     * @type \Decoda\Decoda|\Decoda\Engine\AbstractEngine|\Decoda\Hook\AbstractHook|\Decoda\Filter\AbstractFilter
+     * @var \Decoda\Decoda|\Decoda\Engine\AbstractEngine|\Decoda\Hook\AbstractHook|\Decoda\Filter\AbstractFilter
      */
     protected $object;
 

--- a/tests/Decoda/Test/TestFilter.php
+++ b/tests/Decoda/Test/TestFilter.php
@@ -15,7 +15,7 @@ class TestFilter extends AbstractFilter {
     /**
      * Example tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = array(
         'example' => array(


### PR DESCRIPTION
Hi !

Correct me if i'm wrong, but it seems that the `@type` annotation does not exist (see http://phpdoc.org/docs/latest/glossary.html).

Moreover they cause an error with doctrine annotation reader :

`The annotation "@type" in property Decoda\Component\AbstractComponent::$_config was never imported`
