### PR TITLE
Added better support for encoding problems when escaping a string (available as of PHP 5.4)

### DIFF
--- a/src/Decoda/Decoda.php
+++ b/src/Decoda/Decoda.php
@@ -12,6 +12,10 @@ use Decoda\Exception\MissingHookException;
 use Decoda\Exception\MissingLocaleException;
 use \InvalidArgumentException;
 
+if (!defined('ENT_SUBSTITUTE')) {
+    define('ENT_SUBSTITUTE', 8);
+}
+
 /**
  * A lightweight lexical string parser for simple markup syntax.
  * Provides a very powerful filter and hook system to extend the parsing cycle.
@@ -395,7 +399,7 @@ class Decoda {
         $string = $this->convertNewlines($string);
 
         if ($this->getConfig('escapeHtml')) {
-            $string = htmlspecialchars($string, ENT_NOQUOTES, 'UTF-8', false);
+            $string = htmlspecialchars($string, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
         }
 
         return $string;

--- a/src/Decoda/Filter/AbstractFilter.php
+++ b/src/Decoda/Filter/AbstractFilter.php
@@ -216,7 +216,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
                 }
 
                 if ($setup['escapeAttributes']) {
-                    $value = htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+                    $value = htmlentities($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
                 }
 
                 if (!empty($attributes[$key])) {

--- a/src/templates/quote.php
+++ b/src/templates/quote.php
@@ -10,7 +10,7 @@
             if (!empty($author)) { ?>
                 <span class="decoda-quote-author">
                     <?php echo $this->getFilter()->message('quoteBy', array(
-                        'author' => htmlentities($author, ENT_NOQUOTES, 'UTF-8')
+                        'author' => $this->getParser()->escape($author)
                     )); ?>
                 </span>
             <?php } ?>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| Security fix? | yes |
| New feature? | no |
| Tests pass? | yes |
| License | MIT |

This security fix was took from symfony/symfony@053b42158e2f887b54a3e87977303d219530082f
