### PR TITLE
Speed up emoticon detection

### DIFF
--- a/src/Decoda/Hook/EmoticonHook.php
+++ b/src/Decoda/Hook/EmoticonHook.php
@@ -84,10 +84,8 @@ class EmoticonHook extends AbstractHook {
             return preg_quote($smile, '/');
         }, $smilies));
 
-        $pattern = sprintf('/(?P<left>^|\n|\s)(?:%s)(?P<right>\n|\s|$)/is', $smiliesRegex);
+        $pattern = sprintf('/(?<=^|\s)(?P<smiley>%s)(?=\s|$)/is', $smiliesRegex);
 
-        // Make two passes to accept that one delimiter can use two smilies
-        $content = preg_replace_callback($pattern, array($this, '_emoticonCallback'), $content);
         $content = preg_replace_callback($pattern, array($this, '_emoticonCallback'), $content);
 
         return $content;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | MIT |

With PCRE assertions does not need a second pass anymore.

The callback can be also cleanup.
## BC Breaks
- The first parameter of `Decoda\Hook\EmoticonHook::_emoticonCallback()` method has changed:
  
  Before:
  
  ``` php
  class MyEmoticonHook extends \Decoda\Hook\EmoticonHook
  {
      // ...
      protected function _emoticonCallback($matches) {
           $matches[0];       // contain the text that matches the full pattern
           $matches['left'];  // contain the text at the left of the smiley
           $matches[1];       // contain the text at the left of the smiley
           $matches['right']; // contain the text at the right of the smiley
           $matches[2];       // contain the text at the right of the smiley
      }
      // ...
  }
  ```
  
  Atfer:
  
  ``` php
  class MyEmoticonHook extends \Decoda\Hook\EmoticonHook
  {
      // ...
      protected function _emoticonCallback($matches) {
           $matches[0];        // contain the text that matches the full pattern only the smiley
           $matches[1];        // contain the text of the smiley
           $matches['smiley']; // contain the text of the smiley
      }
      // ...
  }
  ```
