### PR TITLE
Remove useless mb_strtolower on tags name when seeking tags attributes

### DIFF
--- a/src/Decoda/Decoda.php
+++ b/src/Decoda/Decoda.php
@@ -1072,7 +1072,6 @@ class Decoda {
 
             if ($found) {
                 foreach ($found as $key => $value) {
-                    $key = mb_strtolower($key);
                     $value = trim(trim($value), '"');
 
                     if ($key === $tag) {

--- a/tests/Decoda/DecodaTest.php
+++ b/tests/Decoda/DecodaTest.php
@@ -488,6 +488,10 @@ class DecodaTest extends TestCase {
         // All attributes and escaping
         $string = '[attributes="Decoda & Escaping" alpha="Decoda" alnum="Version 1.2.3" numeric="1337" under_score="Underscore" dash-ed="Dashed"]Attributes[/attributes]';
         $this->assertEquals('<attributes id="custom-html" wildcard="Decoda &amp; Escaping" alpha="Decoda" alnum="Version 1.2.3" numeric="1337" under_score="Underscore" dash-ed="Dashed">Attributes</attributes>', $this->object->reset($string)->parse());
+
+        // attributes in cameCase tag must be parsed
+        $string = '[fooBar="hello"]example[/fooBar]';
+        $this->assertEquals('<span class="hello">example</span>', $this->object->reset($string)->parse());
     }
 
     /**

--- a/tests/Decoda/FilterTest.php
+++ b/tests/Decoda/FilterTest.php
@@ -55,6 +55,7 @@ class FilterTest extends TestCase {
             'blockAllowBlock',
             'blockAllowBoth',
             'attributes',
+            'fooBar',
             'parent',
             'parentNoPersist',
             'parentWhitelist',

--- a/tests/Decoda/Test/TestFilter.php
+++ b/tests/Decoda/Test/TestFilter.php
@@ -94,6 +94,18 @@ class TestFilter extends AbstractFilter {
             'escapeAttributes' => true
         ),
 
+        //CamelCase Tag with attributes testing
+        'fooBar' => array(
+            'htmlTag' => 'span',
+            'displayType' => Decoda::TYPE_INLINE,
+            'attributes' => array(
+                'default' => self::WILDCARD,
+            ),
+            'mapAttributes' => array(
+                'default' => 'class'
+            )
+        ),
+
         // Parent child hierarchy
         'parent' => array(
             'htmlTag' => 'parent',


### PR DESCRIPTION
I found this bug using a bbcode in camel case with attributes which was not defined.
It now work without the strtolower locally