### PR TITLE
add spoiler show/hide text toggling

### DIFF
--- a/src/Decoda/Filter/BlockFilter.php
+++ b/src/Decoda/Filter/BlockFilter.php
@@ -20,7 +20,7 @@ class BlockFilter extends AbstractFilter {
      * @type array
      */
     protected $_config = array(
-        'spoilerToggle' => "$('#spoiler-content-{id}').toggle();"
+        'spoilerToggle' => "$('#spoiler-content-{id}').toggle();$(this).text($('#spoiler-content-{id}').is(':visible') ? $(this).attr('data-text-hide') : $(this).attr('data-text-show'));"
     );
 
     /**

--- a/src/templates/spoiler.php
+++ b/src/templates/spoiler.php
@@ -5,7 +5,7 @@ $show = $filter->message('spoiler') . ' (' . $filter->message('show') . ')';
 $hide = $filter->message('spoiler') . ' (' . $filter->message('hide') . ')'; ?>
 
 <div class="decoda-spoiler">
-    <button class="decoda-spoiler-button" type="button" onclick="<?php echo str_replace('{id}', $counter, $spoilerToggle); ?>"><?php echo $show; ?></button>
+    <button class="decoda-spoiler-button" type="button" onclick="<?php echo str_replace('{id}', $counter, $spoilerToggle); ?>" data-text-show="<?php echo $show; ?>" data-text-hide="<?php echo $hide; ?>"><?php echo $show; ?></button>
 
     <div class="decoda-spoiler-content" id="spoiler-content-<?php echo $counter; ?>" style="display: none">
         <?php echo $content; ?>


### PR DESCRIPTION
By default the spoiler button text is `Spoiler (Show)`. When you click on the button and the text displays, the spoiler text should change to `Spoiler (Hide)`.

The spoiler template has both `$show` and `$hide` variables but there's no text replacing going on. This adds said replacement.
