### PR TITLE
replace php 5.7 with 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 5.7
+  - 7.0
   - hhvm
   - hhvm-nightly
 
 matrix:
   allow_failures:
-    - php: 5.7
+    - php: 7.0
     - php: hhvm
     - php: hhvm-nightly
 


### PR DESCRIPTION
PHP 5.7 [never came to fruition](https://wiki.php.net/rfc/php57) and PHP 7.0 has been released!