### PR TITLE
Adding test on ClickableHook which fails in 6.8.0

### DIFF
--- a/tests/Decoda/Hook/ClickableHookTest.php
+++ b/tests/Decoda/Hook/ClickableHookTest.php
@@ -55,6 +55,8 @@ class ClickableHookTest extends TestCase {
         // invalid urls
         $this->assertEquals('http:domain.com', $this->object->beforeParse('http:domain.com'));
         $this->assertEquals('file://image.png', $this->object->beforeParse('file://image.png'));
+
+        $this->assertEquals('<br/><a href="http://domain.com">http://domain.com</a>', $this->object->afterParse('<br/>http://domain.com'));
     }
 
     /**


### PR DESCRIPTION
Hello,

I noticed something between the 6.7.2 and 6.8.0 versions which changes the behavior regarding the `<br/>` tags.

I didn't found a fix for now, but here's a phpunit test showing the error.

In 6.7.2, everything is fine:
```
./vendor/bin/phpunit -c phpunit.xml.dist
PHPUnit 4.8.35 by Sebastian Bergmann and contributors.

...............................................................  63 / 215 ( 29%)
............................................................... 126 / 215 ( 58%)
............................................................... 189 / 215 ( 87%)
..........................

Time: 472 ms, Memory: 21.75MB
```

But in 6.8.0:

```
./vendor/bin/phpunit -c phpunit.xml.dist
PHPUnit 4.8.35 by Sebastian Bergmann and contributors.

...............................................................  63 / 223 ( 28%)
............................................................... 126 / 223 ( 56%)
F.............................................................. 189 / 223 ( 84%)
..................................

Time: 499 ms, Memory: 23.00MB

There was 1 failure:

1) Decoda\Hook\ClickableHookTest::testUrlParsing
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<br/><a href="http://domain.com">http://domain.com</a>'
+'<br/>http://domain.com'

/Users/loic/workspace/decoda/tests/Decoda/Hook/ClickableHookTest.php:59
```

Is this change wanted?