### PR TITLE
Fix url path issue

### DIFF
--- a/src/Decoda/Hook/ClickableHook.php
+++ b/src/Decoda/Hook/ClickableHook.php
@@ -47,12 +47,13 @@ class ClickableHook extends AbstractHook {
 
         if ($parser->hasFilter('Url')) {
             $protocols = $parser->getFilter('Url')->getConfig('protocols');
-            $chars = preg_quote('-_=+|\;:&?/[]%,.!@#$*(){}"\'', '/');
+            $chars = preg_quote('-_=+|\;:&?/%,.!@#$*(){}"\'', '/');
 
             $pattern = implode('', array(
                 '((' . implode('|', $protocols) . ')s?:\/\/([\w\.\+]+:[\w\.\+]+@)?|www\.)', // protocol & login or www. (without http(s))
                 '([\w\-\.]{5,255}+)', // domain, tld
                 '(:[0-9]{0,6}+)?', // port
+                '(\/[a-z0-9' . $chars . ']+)?', // path
                 '(\/?\?[a-z0-9' . $chars . ']+)?', // query
                 '(#[a-z0-9' . $chars . ']+)?' // fragment
             ));

--- a/src/Decoda/Hook/ClickableHook.php
+++ b/src/Decoda/Hook/ClickableHook.php
@@ -47,7 +47,7 @@ class ClickableHook extends AbstractHook {
 
         if ($parser->hasFilter('Url')) {
             $protocols = $parser->getFilter('Url')->getConfig('protocols');
-            $chars = preg_quote('-_=+|\;:&?/%,.!@#$*(){}"\'', '/');
+            $chars = preg_quote('-_=+|\;:&?/%,.~!@#$*(){}"\'', '/');
 
             $pattern = implode('', array(
                 '((' . implode('|', $protocols) . ')s?:\/\/([\w\.\+]+:[\w\.\+]+@)?|www\.)', // protocol & login or www. (without http(s))

--- a/tests/Decoda/Hook/ClickableHookTest.php
+++ b/tests/Decoda/Hook/ClickableHookTest.php
@@ -59,6 +59,12 @@ class ClickableHookTest extends TestCase {
         $this->assertEquals('<b><a href="http://domain.com">http://domain.com</a></b>', $this->object->reset('[b]http://domain.com[/b]')->parse());
         $this->assertEquals('<a href="http://domain.com"><b>http://domain.com</b></a>', $this->object->reset('[url="http://domain.com"][b]http://domain.com[/b][/url]')->parse());
 
+        // test some advanced urls
+        $this->assertEquals('<a href="http://www.domain.com?x=1&amp;y=2#fragment">http://www.domain.com?x=1&amp;y=2#fragment</a>', $this->object->reset('http://www.domain.com?x=1&y=2#fragment')->parse());
+        $this->assertEquals('<a href="http://www.domain.com/?x=1&amp;y=2#fragment">http://www.domain.com/?x=1&amp;y=2#fragment</a>', $this->object->reset('http://www.domain.com/?x=1&y=2#fragment')->parse());
+        $this->assertEquals('<a href="http://www.domain.com/some/deep/path/?x=1&amp;y=2#fragment">http://www.domain.com/some/deep/path/?x=1&amp;y=2#fragment</a>', $this->object->reset('http://www.domain.com/some/deep/path/?x=1&y=2#fragment')->parse());
+        $this->assertEquals('<a href="http://www.domain.com/some/deep/path/#fragment">http://www.domain.com/some/deep/path/#fragment</a>', $this->object->reset('http://www.domain.com/some/deep/path/#fragment')->parse());
+
         // test email url link
         $this->assertEquals('<a href="mailto:test@email.com">test@email.com</a>', $this->object->reset('[url="mailto:test@email.com"]test@email.com[/url]')->parse());
 


### PR DESCRIPTION
Also, a small change: added tilde (~) support and removed support for brackets ([]) in URL.
Why removing brackets?
Because they could lead in including in url adjacent BB code tags such as [b] a.s.o.
I don't think it's a big issue, imho.