### PR TITLE
PHP8 incl PHP7.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ matrix:
     - php: 7.4
       env: CHECKS=1 DEFAULT=0
 
-  allow_failures:
-    - php: nightly
-
 install:
   - |
     if [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.2
+  - 7.3
   - 7.4
   - nightly
+
+env:
+  global:
+    - DEFAULT=1
 
 matrix:
   include:
@@ -15,7 +19,12 @@ matrix:
     - php: nightly
 
 install:
-  - composer install --prefer-source --no-interaction
+  - |
+    if [[ $TRAVIS_PHP_VERSION == 'nightly' ]]; then
+      composer install --no-interaction --ignore-platform-reqs
+    else
+      composer install --no-interaction
+    fi
 
 script:
   - if [[ $DEFAULT == 1 ]]; then vendor/bin/phpunit; fi

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "phpunit/phpunit": "^7.5|^8.5"
+        "phpunit/phpunit": "^8.5"
     },
     "suggest": {
         "ext-redis": "Cache data using Redis",

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.2.0",
         "ext-mbstring": "*"
     },
     "require-dev": {
         "ext-json": "*",
-        "phpunit/phpunit": "^5.7|^7.5"
+        "phpunit/phpunit": "^7.5|^8.5"
     },
     "suggest": {
         "ext-redis": "Cache data using Redis",

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ A lightweight lexical string parser for BBCode styled markup.
 
 ## Requirements
 
-- PHP 5.6.0+
+- PHP 7.2.0+
   - Multibyte
 - Composer
 

--- a/src/Decoda.php
+++ b/src/Decoda.php
@@ -1781,15 +1781,4 @@ class Decoda {
         return $content;
     }
 
-    /**
-     * Trim line breaks and not spaces.
-     *
-     * @deprecated
-     * @param string $string
-     * @return string
-     */
-    protected function _trim($string) {
-        return trim($string, "\t\n\r\0\x0B");
-    }
-
 }

--- a/src/Hook/EmoticonHook.php
+++ b/src/Hook/EmoticonHook.php
@@ -37,7 +37,7 @@ class EmoticonHook extends AbstractHook {
      *
      * @var string[]
      */
-    protected $_smilies = [];
+    protected $_smileys = [];
 
     /**
      * Read the contents of the loaders into the emoticons list.
@@ -62,7 +62,7 @@ class EmoticonHook extends AbstractHook {
             if ($emoticons = $loader->load()) {
                 foreach ($emoticons as $emoticon => $smileys) {
                     foreach ($smileys as $smiley) {
-                        $this->_smilies[$smiley] = $emoticon;
+                        $this->_smileys[$smiley] = $emoticon;
                     }
                 }
 
@@ -107,19 +107,9 @@ class EmoticonHook extends AbstractHook {
      * Returns all available smileys.
      *
      * @return string[]
-     * @deprecated Use getSmileys() instead.
-     */
-    public function getSmilies() {
-        return $this->getSmileys();
-    }
-
-    /**
-     * Returns all available smileys.
-     *
-     * @return string[]
      */
     public function getSmileys() {
-        return array_keys($this->_smilies);
+        return array_keys($this->_smileys);
     }
 
     /**
@@ -129,7 +119,7 @@ class EmoticonHook extends AbstractHook {
      * @return bool
      */
     public function hasSmiley($smiley) {
-        return isset($this->_smilies[$smiley]);
+        return isset($this->_smileys[$smiley]);
     }
 
     /**
@@ -146,7 +136,7 @@ class EmoticonHook extends AbstractHook {
 
         $path = sprintf('%s%s.%s',
             $this->getConfig('path'),
-            $this->_smilies[$smiley],
+            $this->_smileys[$smiley],
             $this->getConfig('extension'));
 
         if ($isXhtml) {

--- a/tests/Decoda/ComponentTest.php
+++ b/tests/Decoda/ComponentTest.php
@@ -17,7 +17,7 @@ class ComponentTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new TestComponent(['key' => 'value']);

--- a/tests/Decoda/DecodaTest.php
+++ b/tests/Decoda/DecodaTest.php
@@ -24,7 +24,7 @@ class DecodaTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new TestFilter());

--- a/tests/Decoda/Engine/PhpEngineTest.php
+++ b/tests/Decoda/Engine/PhpEngineTest.php
@@ -18,7 +18,7 @@ class PhpEngineTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new PhpEngine();

--- a/tests/Decoda/EngineTest.php
+++ b/tests/Decoda/EngineTest.php
@@ -17,7 +17,7 @@ class EngineTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new TestEngine();

--- a/tests/Decoda/Filter/BlockFilterTest.php
+++ b/tests/Decoda/Filter/BlockFilterTest.php
@@ -15,7 +15,7 @@ class BlockFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new BlockFilter());

--- a/tests/Decoda/Filter/CodeFilterTest.php
+++ b/tests/Decoda/Filter/CodeFilterTest.php
@@ -15,7 +15,7 @@ class CodeFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new CodeFilter());

--- a/tests/Decoda/Filter/DefaultFilterTest.php
+++ b/tests/Decoda/Filter/DefaultFilterTest.php
@@ -15,7 +15,7 @@ class DefaultFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new DefaultFilter());

--- a/tests/Decoda/Filter/EmailFilterTest.php
+++ b/tests/Decoda/Filter/EmailFilterTest.php
@@ -15,7 +15,7 @@ class EmailFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new EmailFilter());

--- a/tests/Decoda/Filter/ImageFilterTest.php
+++ b/tests/Decoda/Filter/ImageFilterTest.php
@@ -15,7 +15,7 @@ class ImageFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new ImageFilter());

--- a/tests/Decoda/Filter/ListFilterTest.php
+++ b/tests/Decoda/Filter/ListFilterTest.php
@@ -15,7 +15,7 @@ class ListFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new ListFilter());

--- a/tests/Decoda/Filter/QuoteFilterTest.php
+++ b/tests/Decoda/Filter/QuoteFilterTest.php
@@ -15,7 +15,7 @@ class QuoteFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new QuoteFilter());

--- a/tests/Decoda/Filter/TableFilterTest.php
+++ b/tests/Decoda/Filter/TableFilterTest.php
@@ -15,7 +15,7 @@ class TableFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new TableFilter());

--- a/tests/Decoda/Filter/TextFilterTest.php
+++ b/tests/Decoda/Filter/TextFilterTest.php
@@ -15,7 +15,7 @@ class TextFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new TextFilter());

--- a/tests/Decoda/Filter/UrlFilterTest.php
+++ b/tests/Decoda/Filter/UrlFilterTest.php
@@ -15,7 +15,7 @@ class UrlFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new UrlFilter());

--- a/tests/Decoda/Filter/VideoFilterTest.php
+++ b/tests/Decoda/Filter/VideoFilterTest.php
@@ -15,7 +15,7 @@ class VideoFilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new VideoFilter());

--- a/tests/Decoda/FilterTest.php
+++ b/tests/Decoda/FilterTest.php
@@ -17,7 +17,7 @@ class FilterTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new TestFilter();

--- a/tests/Decoda/Hook/CensorHookTest.php
+++ b/tests/Decoda/Hook/CensorHookTest.php
@@ -18,7 +18,7 @@ class CensorHookTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new CensorHook();

--- a/tests/Decoda/Hook/ClickableHookTest.php
+++ b/tests/Decoda/Hook/ClickableHookTest.php
@@ -21,7 +21,7 @@ class ClickableHookTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->addFilter(new DefaultFilter());

--- a/tests/Decoda/Hook/CodeHookTest.php
+++ b/tests/Decoda/Hook/CodeHookTest.php
@@ -17,7 +17,7 @@ class CodeHookTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new CodeHook();

--- a/tests/Decoda/Hook/EmoticonHookTest.php
+++ b/tests/Decoda/Hook/EmoticonHookTest.php
@@ -18,7 +18,7 @@ class EmoticonHookTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object->setBrackets('[', ']');

--- a/tests/Decoda/HookTest.php
+++ b/tests/Decoda/HookTest.php
@@ -16,7 +16,7 @@ class HookTest extends TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->object = new TestHook();

--- a/tests/Decoda/Test/TestCase.php
+++ b/tests/Decoda/Test/TestCase.php
@@ -21,7 +21,7 @@ class TestCase extends \PHPUnit_Framework_TestCase {
     /**
      * Set up Decoda.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $this->object = new Decoda();
     }
 


### PR DESCRIPTION
Resolves https://github.com/milesj/decoda/issues/148

Requires https://github.com/milesj/decoda/pull/149 to be released first as last minor of PHP5 support.

WIP for a while
we can add more things here.

Since we do make a major here, we can add typehints.

TODO:
- [x] unskip php8 run in travis matrix.
- [ ] Add strict typehints (param and return)
- [ ] Cleanup API? Is there anything that could be done in such a major - or deprecations to be removed?
- [x] Fix `getSmilies()` to getSmileys()