### PR TITLE
Phpstan Level 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,24 @@ language: php
 php:
   - 5.6
   - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
   - 7.4
   - nightly
 
 matrix:
+  include:
+    - php: 7.4
+      env: CHECKS=1 DEFAULT=0
+
   allow_failures:
     - php: nightly
 
 install:
-  - composer install
+  - composer install --prefer-source --no-interaction
 
 script:
-  - vendor/bin/phpunit
+  - if [[ $DEFAULT == 1 ]]; then vendor/bin/phpunit; fi
+
+  - if [[ $CHECKS == 1 ]]; then composer stan-setup && composer stan; fi
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
+        "ext-json": "*",
         "phpunit/phpunit": "^5.7|^7.5"
     },
     "suggest": {
@@ -29,5 +30,9 @@
         "psr-4": {
             "Decoda\\": "src/"
         }
+    },
+    "scripts": {
+        "stan": "phpstan analyse src/",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12.1 && mv composer.backup composer.json"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,9 @@
 parameters:
-    level: 4
+    level: 8
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     bootstrapFiles:
         - %rootDir%/../../../tests/bootstrap.php
     excludes_analyse:
     ignoreErrors:
+        - '#Parameter \#1 \$function of function call_user_func_array expects callable\(\).+AbstractFilter\), mixed\) given.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 4
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
+    bootstrapFiles:
+        - %rootDir%/../../../tests/bootstrap.php
+    excludes_analyse:
+    ignoreErrors:

--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -19,21 +19,21 @@ abstract class AbstractComponent implements Component {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [];
 
     /**
      * List of Loaders.
      *
-     * @type \Decoda\Loader[]
+     * @var \Decoda\Loader[]
      */
     protected $_loaders = [];
 
     /**
      * Decoda object.
      *
-     * @type \Decoda\Decoda
+     * @var \Decoda\Decoda
      */
     protected $_parser;
 

--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -48,7 +48,7 @@ abstract class AbstractComponent implements Component {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function addLoader(Loader $loader) {
         $this->_loaders[] = $loader;
@@ -57,42 +57,42 @@ abstract class AbstractComponent implements Component {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function construct() {
         return;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getConfig($key) {
         return isset($this->_config[$key]) ? $this->_config[$key] : null;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getLoaders() {
         return $this->_loaders;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getParser() {
         return $this->_parser;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function message($key, array $vars = []) {
         return $this->getParser()->message($key, $vars);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setConfig(array $config) {
         $this->_config = $config + $this->_config;
@@ -101,7 +101,7 @@ abstract class AbstractComponent implements Component {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setParser(Decoda $parser) {
         $this->_parser = $parser;

--- a/src/Decoda.php
+++ b/src/Decoda.php
@@ -158,7 +158,7 @@ class Decoda {
     /**
      * Caching engine.
      *
-     * @type \Decoda\Storage
+     * @type \Decoda\Storage|null
      */
     protected $_storage;
 
@@ -592,7 +592,7 @@ class Decoda {
     /**
      * Return the current storage engine.
      *
-     * @return \Decoda\Storage
+     * @return \Decoda\Storage|null
      */
     public function getStorage() {
         return $this->_storage;
@@ -932,7 +932,7 @@ class Decoda {
     }
 
     /**
-     * Toggle whether standalone tags (self-closing tags without the 
+     * Toggle whether standalone tags (self-closing tags without the
      * trailing slash) are allowed.
      *
      * @param bool $status
@@ -1133,7 +1133,7 @@ class Decoda {
         }
 
         if (!isset($this->_tags[$tag])) {
-            return false;
+            return [];
         }
 
         $source = $this->_tags[$tag];
@@ -1236,7 +1236,7 @@ class Decoda {
      *
      * @param array $chunks
      * @param array $wrapper
-     * @return string
+     * @return array
      */
     protected function _cleanChunks(array $chunks, array $wrapper = []) {
         $clean = [];
@@ -1602,27 +1602,22 @@ class Decoda {
      */
     protected function _isAllowed($parent, $tag) {
         $filter = $this->getFilterByTag($tag);
-
-        if (!$filter) {
-            return false;
-        }
-
         $child = $filter->getTag($tag);
 
         // Remove children after a certain nested depth
         if (isset($parent['currentDepth']) && $parent['maxChildDepth'] >= 0 && $parent['currentDepth'] > $parent['maxChildDepth']) {
             return false;
-
+        }
         // Children that can only be within a certain parent
-        } else if ($child['parent'] && !in_array($parent['tag'], $child['parent'])) {
+        if ($child['parent'] && !in_array($parent['tag'], $child['parent'])) {
             return false;
-
+        }
         // Parents that can not have specific direct descendant children
-        } else if ($parent['childrenBlacklist'] && in_array($child['tag'], $parent['childrenBlacklist'])) {
+        if ($parent['childrenBlacklist'] && in_array($child['tag'], $parent['childrenBlacklist'])) {
             return false;
-
+        }
         // Parents that can only have direct descendant children
-        } else if ($parent['childrenWhitelist'] && !in_array($child['tag'], $parent['childrenWhitelist'])) {
+        if ($parent['childrenWhitelist'] && !in_array($child['tag'], $parent['childrenWhitelist'])) {
             return false;
         }
 
@@ -1633,13 +1628,13 @@ class Decoda {
                 if ($child['displayType'] === self::TYPE_INLINE) {
                     return true;
                 }
-            break;
+                break;
             case self::TYPE_BLOCK:
                 // Block types only allowed if the parent is also a block
                 if ($parent['displayType'] === self::TYPE_BLOCK && $child['displayType'] === self::TYPE_BLOCK) {
                     return true;
                 }
-            break;
+                break;
             case self::TYPE_BOTH:
                 if ($parent['displayType'] === self::TYPE_INLINE) {
                     // Only allow inline if parent is inline
@@ -1649,7 +1644,7 @@ class Decoda {
                 } else {
                     return true;
                 }
-            break;
+                break;
         }
 
         // Log the error

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -31,7 +31,7 @@ interface Engine extends Component {
     /**
      * Returns the paths to the templates.
      *
-     * @return string
+     * @return string[]
      */
     public function getPaths();
 

--- a/src/Engine/AbstractEngine.php
+++ b/src/Engine/AbstractEngine.php
@@ -19,14 +19,14 @@ abstract class AbstractEngine extends AbstractComponent implements Engine {
     /**
      * Lookup paths.
      *
-     * @type string[]
+     * @var string[]
      */
     protected $_paths = [];
 
     /**
      * Current filter.
      *
-     * @type \Decoda\Filter
+     * @var \Decoda\Filter
      */
     protected $_filter;
 

--- a/src/Engine/AbstractEngine.php
+++ b/src/Engine/AbstractEngine.php
@@ -19,7 +19,7 @@ abstract class AbstractEngine extends AbstractComponent implements Engine {
     /**
      * Lookup paths.
      *
-     * @type array
+     * @type string[]
      */
     protected $_paths = [];
 
@@ -31,7 +31,7 @@ abstract class AbstractEngine extends AbstractComponent implements Engine {
     protected $_filter;
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function addPath($path) {
         if (substr($path, -1) !== '/') {
@@ -54,21 +54,21 @@ abstract class AbstractEngine extends AbstractComponent implements Engine {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getFilter() {
         return $this->_filter;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getPaths() {
         return $this->_paths;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setFilter(Filter $filter) {
         $this->_filter = $filter;

--- a/src/Engine/PhpEngine.php
+++ b/src/Engine/PhpEngine.php
@@ -37,7 +37,9 @@ class PhpEngine extends AbstractEngine {
 
                 include $template;
 
-                return trim(ob_get_clean());
+                $result = ob_get_clean();
+
+                return $result === false ? '' : trim($result);
             }
         }
 

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -21,7 +21,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
     /**
      * Default tag configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_defaults = [
         /**
@@ -87,7 +87,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [];
 

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -148,14 +148,14 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getTags() {
         return $this->_tags;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function parse(array $tag, $content) {
         $setup = $this->getTag($tag['tag']);
@@ -165,7 +165,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
 
         // Test for an empty filter or empty tag
         if (!$setup || (!$content && $parser->getConfig('removeEmpty'))) {
-            return null;
+            return '';
         }
 
         // Merge arguments with method of same tag name
@@ -174,7 +174,7 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
             if ($response = call_user_func_array([$this, $tag['tag']], [$tag, $content])) {
                 list($tag, $content) = $response;
             } else {
-                return null;
+                return '';
             }
         }
 
@@ -260,14 +260,14 @@ abstract class AbstractFilter extends AbstractComponent implements Filter {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setupHooks(Decoda $decoda) {
         return $this;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function strip(array $tag, $content) {
         $setup = $this->getTag($tag['tag']);

--- a/src/Filter/BlockFilter.php
+++ b/src/Filter/BlockFilter.php
@@ -17,7 +17,7 @@ class BlockFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'align' => [

--- a/src/Filter/CodeFilter.php
+++ b/src/Filter/CodeFilter.php
@@ -18,7 +18,7 @@ class CodeFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [
         'classPrefix' => 'lang-',
@@ -28,7 +28,7 @@ class CodeFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'code' => [

--- a/src/Filter/DefaultFilter.php
+++ b/src/Filter/DefaultFilter.php
@@ -18,7 +18,7 @@ class DefaultFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [
         'timeFormat' => 'D, M jS Y, H:i'
@@ -27,7 +27,7 @@ class DefaultFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'b' => [
@@ -100,9 +100,9 @@ class DefaultFilter extends AbstractFilter {
     public function time(array $tag, $content) {
         $timestamp = is_numeric($content) ? $content : strtotime($content);
 
-        $content = date($this->getConfig('timeFormat'), $timestamp);
+        $content = date($this->getConfig('timeFormat'), (int)$timestamp);
 
-        $tag['attributes']['datetime'] = date(DateTime::ISO8601, $timestamp);
+        $tag['attributes']['datetime'] = date(DateTime::ATOM, (int)$timestamp);
 
         return [$tag, $content];
     }

--- a/src/Filter/EmailFilter.php
+++ b/src/Filter/EmailFilter.php
@@ -17,7 +17,7 @@ class EmailFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [
         'encrypt' => true
@@ -26,7 +26,7 @@ class EmailFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'email' => [

--- a/src/Filter/EmptyFilter.php
+++ b/src/Filter/EmptyFilter.php
@@ -15,7 +15,7 @@ class EmptyFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'root' => []

--- a/src/Filter/ImageFilter.php
+++ b/src/Filter/ImageFilter.php
@@ -56,10 +56,9 @@ class ImageFilter extends AbstractFilter {
      * @return string
      */
     public function parse(array $tag, $content) {
-
         // If more than 1 http:// is found in the string, possible XSS attack
         if ((mb_substr_count($content, 'http://') + mb_substr_count($content, 'https://')) > 1) {
-            return null;
+            return '';
         }
 
         $tag['attributes']['src'] = $content;

--- a/src/Filter/ImageFilter.php
+++ b/src/Filter/ImageFilter.php
@@ -24,7 +24,7 @@ class ImageFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'img' => [

--- a/src/Filter/ListFilter.php
+++ b/src/Filter/ListFilter.php
@@ -19,7 +19,7 @@ class ListFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'olist' => [

--- a/src/Filter/QuoteFilter.php
+++ b/src/Filter/QuoteFilter.php
@@ -17,7 +17,7 @@ class QuoteFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [
         'dateFormat' => 'M jS Y, H:i:s'
@@ -26,7 +26,7 @@ class QuoteFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'quote' => [

--- a/src/Filter/TableFilter.php
+++ b/src/Filter/TableFilter.php
@@ -17,7 +17,7 @@ class TableFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'table' => [

--- a/src/Filter/TextFilter.php
+++ b/src/Filter/TextFilter.php
@@ -17,7 +17,7 @@ class TextFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'font' => [

--- a/src/Filter/UrlFilter.php
+++ b/src/Filter/UrlFilter.php
@@ -17,7 +17,7 @@ class UrlFilter extends AbstractFilter {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [
         'protocols' => ['http', 'https', 'ftp', 'irc', 'telnet', 'mailto'],
@@ -27,7 +27,7 @@ class UrlFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'url' => [
@@ -60,7 +60,7 @@ class UrlFilter extends AbstractFilter {
         $defaultProtocol = $this->getConfig('defaultProtocol');
         $hasProtocol = preg_match('/^(' . implode('|', $protocols) . ')/i', $url);
 
-        if (!in_array($defaultProtocol, $protocols)) {
+        if (!in_array($defaultProtocol, $protocols, true)) {
             $defaultProtocol = 'http';
         }
 

--- a/src/Filter/VideoFilter.php
+++ b/src/Filter/VideoFilter.php
@@ -23,7 +23,7 @@ class VideoFilter extends AbstractFilter {
     /**
      * Supported tags.
      *
-     * @type array
+     * @var array
      */
     protected $_tags = [
         'video' => [
@@ -131,7 +131,7 @@ class VideoFilter extends AbstractFilter {
     /**
      * Video formats.
      *
-     * @type array
+     * @var array
      */
     protected $_formats = [
         'youtube' => [

--- a/src/Hook/AbstractHook.php
+++ b/src/Hook/AbstractHook.php
@@ -17,56 +17,56 @@ use Decoda\Hook;
 abstract class AbstractHook extends AbstractComponent implements Hook {
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function afterContent($content) {
         return $content;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function afterParse($content) {
         return $content;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function afterStrip($content) {
         return $content;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function beforeContent($content) {
         return $content;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function beforeParse($content) {
         return $content;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function beforeStrip($content) {
         return $content;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function startup() {
         return;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setupFilters(Decoda $decoda) {
         return $this;

--- a/src/Hook/CensorHook.php
+++ b/src/Hook/CensorHook.php
@@ -18,14 +18,14 @@ class CensorHook extends AbstractHook {
     /**
      * List of words to censor.
      *
-     * @type array
+     * @var array
      */
     protected $_blacklist = [];
 
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [
         'suffix' => ['ing', 'in', 'er', 'r', 'ed', 'd']
@@ -41,7 +41,8 @@ class CensorHook extends AbstractHook {
 
         // Load files from config paths
         foreach ($this->getParser()->getPaths() as $path) {
-            foreach (glob($path . 'censored.*') as $file) {
+            $files = glob($path . 'censored.*') ?: [];
+            foreach ($files as $file) {
                 $this->addLoader(new FileLoader($file));
             }
         }
@@ -106,7 +107,7 @@ class CensorHook extends AbstractHook {
      */
     protected function _censor($content) {
         $pattern = implode('|', array_map([$this, '_prepareRegex'], $this->getBlacklist()));
-        $content = preg_replace_callback('/(?:^|\b)(?:' . $pattern . ')(?:\b|$)/is', [$this, '_censorCallback'], $content);
+        $content = (string)preg_replace_callback('/(?:^|\b)(?:' . $pattern . ')(?:\b|$)/is', [$this, '_censorCallback'], $content);
 
         return $content;
     }

--- a/src/Hook/ClickableHook.php
+++ b/src/Hook/ClickableHook.php
@@ -37,7 +37,7 @@ class ClickableHook extends AbstractHook {
                 $matches = array_unique(array_map(function($x) { return $x[0]; }, $matches));
 
                 foreach ($matches as $val) {
-                    $uniqid = uniqid($i++);
+                    $uniqid = uniqid((string)($i++), true);
 
                     $ignoredStrings[$uniqid] = $val;
                     $content = str_replace($val, $uniqid, $content);
@@ -58,14 +58,14 @@ class ClickableHook extends AbstractHook {
                 '(#[a-z0-9' . $chars . ']+)?' // fragment
             ]);
 
-            $content = preg_replace_callback('/(' . $pattern . ')/i', [$this, '_urlCallback'], $content);
+            $content = (string)preg_replace_callback('/(' . $pattern . ')/i', [$this, '_urlCallback'], $content);
         }
 
         // Based on W3C HTML5 spec: https://www.w3.org/TR/html5/forms.html#valid-e-mail-address
         if ($parser->hasFilter('Email')) {
             $pattern = '(:\/\/[\w\.\+]+:)?([a-z0-9.!#$%&\'*+\/=?^_`{|}~\-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*)';
 
-            $content = preg_replace_callback('/' . $pattern . '/i', [$this, '_emailCallback'], $content);
+            $content = (string)preg_replace_callback('/' . $pattern . '/i', [$this, '_emailCallback'], $content);
         }
 
         // We restore the tags we ommited

--- a/src/Hook/EmoticonHook.php
+++ b/src/Hook/EmoticonHook.php
@@ -18,7 +18,7 @@ class EmoticonHook extends AbstractHook {
     /**
      * Configuration.
      *
-     * @type array
+     * @var array
      */
     protected $_config = [
         'path' => '/images/',
@@ -28,14 +28,14 @@ class EmoticonHook extends AbstractHook {
     /**
      * Mapping of emoticons to smilies.
      *
-     * @type array
+     * @var array
      */
     protected $_emoticons = [];
 
     /**
      * Map of smilies to emoticons.
      *
-     * @type array
+     * @var array
      */
     protected $_smilies = [];
 
@@ -49,7 +49,8 @@ class EmoticonHook extends AbstractHook {
 
         // Load files from config paths
         foreach ($this->getParser()->getPaths() as $path) {
-            foreach (glob($path . 'emoticons.*') as $file) {
+            $files = glob($path . 'emoticons.*') ?: [];
+            foreach ($files as $file) {
                 $this->addLoader(new FileLoader($file));
             }
         }
@@ -85,10 +86,10 @@ class EmoticonHook extends AbstractHook {
         }, $smilies));
 
         $pattern = sprintf('/(?:(?<=[\s.;>:)])|^)(%s)/', $smiliesRegex);
-        $content = preg_replace_callback($pattern, [$this, '_emoticonCallback'], $content);
+        $content = (string)preg_replace_callback($pattern, [$this, '_emoticonCallback'], $content);
 
         $pattern = sprintf('/(%s)(?:(?=[\s.&<:(])|$)/', $smiliesRegex);
-        $content = preg_replace_callback($pattern, [$this, '_emoticonCallback'], $content);
+        $content = (string)preg_replace_callback($pattern, [$this, '_emoticonCallback'], $content);
 
         return $content;
     }

--- a/src/Hook/EmoticonHook.php
+++ b/src/Hook/EmoticonHook.php
@@ -130,7 +130,7 @@ class EmoticonHook extends AbstractHook {
      */
     public function render($smiley, $isXhtml = true) {
         if (!$this->hasSmiley($smiley)) {
-            return null;
+            return '';
         }
 
         $path = sprintf('%s%s.%s',

--- a/src/Loader/DataLoader.php
+++ b/src/Loader/DataLoader.php
@@ -15,7 +15,7 @@ class DataLoader extends AbstractLoader {
     /**
      * Raw data.
      *
-     * @type mixed
+     * @var mixed
      */
     protected $_data;
 

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -48,16 +48,12 @@ class FileLoader extends AbstractLoader {
         switch ($ext) {
             case 'php':
                 return include $this->_path;
-            break;
             case 'json':
-                return json_decode(file_get_contents($this->_path), true);
-            break;
+                return json_decode(file_get_contents($this->_path), true) ?: [];
             case 'ini':
-                return parse_ini_file($this->_path, true);
-            break;
+                return parse_ini_file($this->_path, true) ?: [];
             case 'txt':
-                return file($this->_path, FILE_IGNORE_NEW_LINES);
-            break;
+                return file($this->_path, FILE_IGNORE_NEW_LINES) ?: [];
         }
 
         throw new UnsupportedTypeException(sprintf('Unsupported FileLoader file type %s', $ext));

--- a/src/Loader/FileLoader.php
+++ b/src/Loader/FileLoader.php
@@ -18,7 +18,7 @@ class FileLoader extends AbstractLoader {
     /**
      * Path to file.
      *
-     * @type string
+     * @var string
      */
     protected $_path;
 
@@ -49,7 +49,11 @@ class FileLoader extends AbstractLoader {
             case 'php':
                 return include $this->_path;
             case 'json':
-                return json_decode(file_get_contents($this->_path), true) ?: [];
+                $content = file_get_contents($this->_path);
+                if ($content === false) {
+                    throw new \RuntimeException('Cannot open file: ' . $this->_path);
+                }
+                return json_decode($content, true) ?: [];
             case 'ini':
                 return parse_ini_file($this->_path, true) ?: [];
             case 'txt':

--- a/src/Storage/MemcacheStorage.php
+++ b/src/Storage/MemcacheStorage.php
@@ -8,7 +8,7 @@
 namespace Decoda\Storage;
 
 use Decoda\Exception\MissingItemException;
-use \Memcached;
+use Memcached;
 
 /**
  * Cache data using Memcache.
@@ -32,7 +32,7 @@ class MemcacheStorage extends AbstractStorage {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function get($key) {
         $value = $this->getMemcache()->get($key);
@@ -54,7 +54,7 @@ class MemcacheStorage extends AbstractStorage {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function has($key) {
         return (
@@ -64,14 +64,14 @@ class MemcacheStorage extends AbstractStorage {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function remove($key) {
         return $this->getMemcache()->delete($key);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function set($key, $value, $expires) {
         return $this->getMemcache()->set($key, $value, (int) $expires);

--- a/src/Storage/MemoryStorage.php
+++ b/src/Storage/MemoryStorage.php
@@ -22,7 +22,7 @@ class MemoryStorage extends AbstractStorage {
     protected $_cache = [];
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function get($key) {
         if (!$this->has($key)) {
@@ -33,14 +33,14 @@ class MemoryStorage extends AbstractStorage {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function has($key) {
         return isset($this->_cache[$key]);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function remove($key) {
         unset($this->_cache[$key]);
@@ -49,7 +49,7 @@ class MemoryStorage extends AbstractStorage {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function set($key, $value, $expires) {
         $this->_cache[$key] = $value;

--- a/src/Storage/RedisStorage.php
+++ b/src/Storage/RedisStorage.php
@@ -8,7 +8,7 @@
 namespace Decoda\Storage;
 
 use Decoda\Exception\MissingItemException;
-use \Redis;
+use Redis;
 
 /**
  * Cache data using Redis.
@@ -32,7 +32,7 @@ class RedisStorage extends AbstractStorage {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function get($key) {
         $value = $this->getRedis()->get($key);
@@ -54,21 +54,21 @@ class RedisStorage extends AbstractStorage {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function has($key) {
-        return $this->getRedis()->exists($key);
+        return (bool)$this->getRedis()->exists($key);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function remove($key) {
-        return (bool) $this->getRedis()->delete($key);
+        return (bool)$this->getRedis()->del($key);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function set($key, $value, $expires) {
         return $this->getRedis()->setex($key, (int) $expires - time(), $value); // Redis is TTL

--- a/tests/Decoda/Filter/DefaultFilterTest.php
+++ b/tests/Decoda/Filter/DefaultFilterTest.php
@@ -106,7 +106,7 @@ class DefaultFilterTest extends TestCase {
     public function testTime() {
         $oldTZ = date_default_timezone_get();
         date_default_timezone_set('UTC');
-        $this->assertEquals('<time datetime="1988-02-26T20:34:13+0000">Fri, Feb 26th 1988, 20:34</time>', $this->object->reset('[time]2/26/1988 20:34:13[/time]')->parse());
+        $this->assertEquals('<time datetime="1988-02-26T20:34:13+00:00">Fri, Feb 26th 1988, 20:34</time>', $this->object->reset('[time]2/26/1988 20:34:13[/time]')->parse());
         date_default_timezone_set($oldTZ);
     }
 


### PR DESCRIPTION
In light of upcoming PHP8 and more strictness, I added PHPStan level 8 (highest) now.
There are some slight changes around edge case handling, but it seems those would be acceptable (as those return types are documented or expected anyway).

Once we are PHP7.2+ we can then make phpstan being installed directly. So far we need to use composer scripts here.