### PR TITLE
Fix documented typehints. Fix getSmileys()

### DIFF
--- a/src/Decoda.php
+++ b/src/Decoda.php
@@ -64,13 +64,6 @@ class Decoda {
     const NL_CONVERT = 2;
 
     /**
-     * Blacklist of tags not to parse.
-     *
-     * @var array
-     */
-    protected $_blacklist = [];
-
-    /**
      * Unique cache key for this block.
      *
      * @var string
@@ -109,21 +102,21 @@ class Decoda {
     /**
      * List of all instantiated filter objects.
      *
-     * @var array
+     * @var \Decoda\Filter[]
      */
     protected $_filters = [];
 
     /**
      * Mapping of tags to its filter object.
      *
-     * @var array
+     * @var string[]
      */
     protected $_filterMap = [];
 
     /**
      * List of all instantiated hook objects.
      *
-     * @var array
+     * @var \Decoda\Hook[]
      */
     protected $_hooks = [];
 
@@ -151,7 +144,7 @@ class Decoda {
     /**
      * Configuration folder paths.
      *
-     * @var array
+     * @var string[]
      */
     protected $_paths = [];
 
@@ -191,9 +184,16 @@ class Decoda {
     protected $_engine;
 
     /**
+     * Blacklist of tags not to parse.
+     *
+     * @var string[]
+     */
+    protected $_blacklist = [];
+
+    /**
      * Whitelist of tags to parse.
      *
-     * @var array
+     * @var string[]
      */
     protected $_whitelist = [];
 
@@ -447,7 +447,7 @@ class Decoda {
     /**
      * Return the current blacklist.
      *
-     * @return array
+     * @return string[]
      */
     public function getBlacklist() {
         return $this->_blacklist;
@@ -535,7 +535,7 @@ class Decoda {
     /**
      * Return all filters.
      *
-     * @return array
+     * @return \Decoda\Filter[]
      */
     public function getFilters() {
         return $this->_filters;
@@ -559,7 +559,7 @@ class Decoda {
     /**
      * Return all hooks.
      *
-     * @return array
+     * @return \Decoda\Hook[]
      */
     public function getHooks() {
         return $this->_hooks;
@@ -587,7 +587,7 @@ class Decoda {
     /**
      * Return the configuration folder paths.
      *
-     * @return array
+     * @return string[]
      */
     public function getPaths() {
         return $this->_paths;
@@ -605,7 +605,7 @@ class Decoda {
     /**
      * Return the current whitelist.
      *
-     * @return array
+     * @return string[]
      */
     public function getWhitelist() {
         return $this->_whitelist;
@@ -615,7 +615,7 @@ class Decoda {
      * Check if a filter exists.
      *
      * @param string $filter
-     * @return boolean
+     * @return bool
      */
     public function hasFilter($filter) {
         return isset($this->_filters[$filter]);
@@ -625,7 +625,7 @@ class Decoda {
      * Check if a hook exists.
      *
      * @param string $hook
-     * @return boolean
+     * @return bool
      */
     public function hasHook($hook) {
         return isset($this->_hooks[$hook]);
@@ -743,7 +743,7 @@ class Decoda {
     /**
      * Remove hook(s).
      *
-     * @param string|array $hooks
+     * @param string|string[] $hooks
      * @return \Decoda\Decoda
      */
     public function removeHook($hooks) {
@@ -1609,7 +1609,7 @@ class Decoda {
      *
      * @param array $parent
      * @param string $tag
-     * @return boolean
+     * @return bool
      */
     protected function _isAllowed($parent, $tag) {
         $filter = $this->getFilterByTag($tag);
@@ -1675,7 +1675,7 @@ class Decoda {
      * Return true if the string is parseable.
      *
      * @param string $string
-     * @return boolean
+     * @return bool
      */
     protected function _isParseable($string) {
         return (

--- a/src/Hook/CensorHook.php
+++ b/src/Hook/CensorHook.php
@@ -18,7 +18,7 @@ class CensorHook extends AbstractHook {
     /**
      * List of words to censor.
      *
-     * @var array
+     * @var string[]
      */
     protected $_blacklist = [];
 
@@ -80,7 +80,7 @@ class CensorHook extends AbstractHook {
     /**
      * Add words to the blacklist.
      *
-     * @param array $words
+     * @param string[] $words
      * @return \Decoda\Hook\CensorHook
      */
     public function blacklist(array $words) {
@@ -93,7 +93,7 @@ class CensorHook extends AbstractHook {
     /**
      * Return the current blacklist.
      *
-     * @return array
+     * @return string[]
      */
     public function getBlacklist() {
         return $this->_blacklist;
@@ -115,7 +115,7 @@ class CensorHook extends AbstractHook {
     /**
      * Censor a word if its only by itself.
      *
-     * @param array $matches
+     * @param string[] $matches
      * @return string
      */
     protected function _censorCallback($matches) {

--- a/src/Hook/ClickableHook.php
+++ b/src/Hook/ClickableHook.php
@@ -79,7 +79,7 @@ class ClickableHook extends AbstractHook {
     /**
      * Callback for email processing.
      *
-     * @param array $matches
+     * @param string[] $matches
      * @return string
      */
     protected function _emailCallback($matches) {
@@ -97,7 +97,7 @@ class ClickableHook extends AbstractHook {
     /**
      * Callback for URL processing.
      *
-     * @param array $matches
+     * @param string[] $matches
      * @return string
      */
     protected function _urlCallback($matches) {

--- a/src/Hook/CodeHook.php
+++ b/src/Hook/CodeHook.php
@@ -15,7 +15,7 @@ class CodeHook extends AbstractHook {
     /**
      * Cached code blocks during the parsing process.
      *
-     * @var array
+     * @var string[]
      */
     protected $_cache = [];
 
@@ -49,7 +49,7 @@ class CodeHook extends AbstractHook {
     /**
      * Encode content using base64.
      *
-     * @param array $matches
+     * @param string[] $matches
      * @return string
      */
     protected function _encodeCallback(array $matches) {
@@ -62,7 +62,7 @@ class CodeHook extends AbstractHook {
     /**
      * Decode content using base64.
      *
-     * @param array $matches
+     * @param string[] $matches
      * @return string
      */
     protected function _decodeCallback(array $matches) {

--- a/src/Hook/EmoticonHook.php
+++ b/src/Hook/EmoticonHook.php
@@ -26,16 +26,16 @@ class EmoticonHook extends AbstractHook {
     ];
 
     /**
-     * Mapping of emoticons to smilies.
+     * Mapping of emoticons to smileys.
      *
      * @var array
      */
     protected $_emoticons = [];
 
     /**
-     * Map of smilies to emoticons.
+     * Map of smileys to emoticons.
      *
-     * @var array
+     * @var string[]
      */
     protected $_smilies = [];
 
@@ -60,9 +60,9 @@ class EmoticonHook extends AbstractHook {
             $loader->setParser($this->getParser());
 
             if ($emoticons = $loader->load()) {
-                foreach ($emoticons as $emoticon => $smilies) {
-                    foreach ($smilies as $smile) {
-                        $this->_smilies[$smile] = $emoticon;
+                foreach ($emoticons as $emoticon => $smileys) {
+                    foreach ($smileys as $smiley) {
+                        $this->_smilies[$smiley] = $emoticon;
                     }
                 }
 
@@ -78,24 +78,24 @@ class EmoticonHook extends AbstractHook {
      * @return string
      */
     public function afterParse($content) {
-        $smilies = $this->getSmilies();
+        $smileys = $this->getSmileys();
 
-        // Build the smilies regex
-        $smiliesRegex = implode('|', array_map(function ($smile) {
-            return preg_quote($smile, '/');
-        }, $smilies));
+        // Build the smileys regex
+        $smileysRegex = implode('|', array_map(function ($smiley) {
+            return preg_quote($smiley, '/');
+        }, $smileys));
 
-        $pattern = sprintf('/(?:(?<=[\s.;>:)])|^)(%s)/', $smiliesRegex);
+        $pattern = sprintf('/(?:(?<=[\s.;>:)])|^)(%s)/', $smileysRegex);
         $content = (string)preg_replace_callback($pattern, [$this, '_emoticonCallback'], $content);
 
-        $pattern = sprintf('/(%s)(?:(?=[\s.&<:(])|$)/', $smiliesRegex);
+        $pattern = sprintf('/(%s)(?:(?=[\s.&<:(])|$)/', $smileysRegex);
         $content = (string)preg_replace_callback($pattern, [$this, '_emoticonCallback'], $content);
 
         return $content;
     }
 
     /**
-     * Gets the mapping of emoticons and smilies.
+     * Gets the mapping of emoticons and smileys.
      *
      * @return array
      */
@@ -104,11 +104,21 @@ class EmoticonHook extends AbstractHook {
     }
 
     /**
-     * Returns all available smilies.
+     * Returns all available smileys.
      *
-     * @return array
+     * @return string[]
+     * @deprecated Use getSmileys() instead.
      */
     public function getSmilies() {
+        return $this->getSmileys();
+    }
+
+    /**
+     * Returns all available smileys.
+     *
+     * @return string[]
+     */
+    public function getSmileys() {
         return array_keys($this->_smilies);
     }
 
@@ -151,7 +161,7 @@ class EmoticonHook extends AbstractHook {
     /**
      * Callback for smiley processing.
      *
-     * @param array $matches
+     * @param string[] $matches
      * @return string
      */
     protected function _emoticonCallback($matches) {


### PR DESCRIPTION
Add getSmileys()
Deprecated getSmilies()

fix up docblock typehints to the concrete type where applicable.