### PR TITLE
Move changelog to github releases.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 _These logs may be outdated or incomplete._
 
+Note: With this 6.13.0 release the changelog has been moved to GitHub releases.
+See last ones there, these here are only for historic reasons.
+
 ## 6.13.0
 
 - Updated to PSR-4 and to support PHP 7.4.


### PR DESCRIPTION
I would like to propose moving the changelog to GitHub
https://github.com/milesj/decoda/releases

This way, they are more readable directly, and could also be modified post release if sth was missing.
The current "shipped" way is not that flexible.

Using GitHub here is also free and the recommended way, and so far unused.


Also: I think we are now ready for the 6.13 milestone
Unless there are some fixes you also want to ship along with it?