### PR TITLE
Fix phpdoc for Decoda::setMaxNewlines

### DIFF
--- a/src/Decoda.php
+++ b/src/Decoda.php
@@ -963,7 +963,7 @@ class Decoda {
     /**
      * Set the max amount of newlines.
      *
-     * @param bool $max
+     * @param int $max
      * @return \Decoda\Decoda
      */
     public function setMaxNewlines($max) {


### PR DESCRIPTION
The method setMaxNewlines in class Decoda accept int but the phpdoc @param says bool.